### PR TITLE
Add parsing of an additional, local config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dixit/static/cards/*
 *.egg-info
 build
 dist
+config.local.json

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ Release history
 
 - Added the ability for hosts to hide their games from the table.
   (`#11 <https://github.com/arvoelke/Dixit/pull/11>`__)
+- Configuration settings may be overriden by another config file.
+  (`#10 <https://github.com/arvoelke/Dixit/pull/10>`__)
 
 
 0.1.1 (July 10, 2020)

--- a/README.rst
+++ b/README.rst
@@ -16,9 +16,25 @@ Then go to http://localhost:8888/.
 Configuring the Server
 ----------------------
 
-Edit ``dixit/config.json`` to specify which port to run on (default
-8888), and to point to the location of each card deck that you have
-(e.g., see ``dixit/static/cards/dixit/README.txt``).
+Configuration options, such as the port (default 8888), and the location of
+each card deck (e.g., see ``dixit/static/cards/dixit/README.txt``), are housed
+in JSON configuration files that are read when you launch the server.
+Default settings are located in ``dixit/config.json``.
+
+To override the defaults, you may create a JSON file in your working directory
+that contains a subset of these configuration options. For example, to change
+the port to 9000, create a new file named ``config.local.json`` that contains:
+```
+{
+    "port": 9000
+}
+```
+Then pass in this file name when you launch the server, as in:
+``dixit config.local.json``. This will override the default configuration with
+the values in ``config.local.json``.
+
+Alternatively, directly edit ``dixit/config.json``, to for instance, specify
+which port to use, or to point to the location of each card deck that you have.
 
 Disclaimer
 ----------

--- a/dixit/config.py
+++ b/dixit/config.py
@@ -1,9 +1,8 @@
 """Helper file for parsing a JSON config file with comments."""
 
+from copy import deepcopy
 import json
 import re
-
-from copy import deepcopy
 
 RE_REMOVE_COMMENTS = re.compile(r'\/\/[^\n]*')
 
@@ -15,6 +14,7 @@ def _parse(config_filename):
     config_json = RE_REMOVE_COMMENTS.sub('', config_json)
     return json.loads(config_json)
 
+
 def _merge(old, new):
     result = deepcopy(old)
     for key, value in new.items():
@@ -24,12 +24,9 @@ def _merge(old, new):
 
     return result
 
-def parse(default_config_filename, override_config_filename = None):
+
+def parse(default_config_filename, override_config_filename=None):
     config = _parse(default_config_filename)
     if override_config_filename:
-        try:
-            config = _merge(config, _parse(override_config_filename))
-        except FileNotFoundError:
-            pass
-
+        config = _merge(config, _parse(override_config_filename))
     return config

--- a/dixit/config.py
+++ b/dixit/config.py
@@ -3,12 +3,33 @@
 import json
 import re
 
+from copy import deepcopy
+
 RE_REMOVE_COMMENTS = re.compile(r'\/\/[^\n]*')
 
 
-def parse(config_filename):
+def _parse(config_filename):
     """Returns the json structure in the file with the given name."""
     with open(config_filename, 'r') as config_file:
         config_json = config_file.read()
     config_json = RE_REMOVE_COMMENTS.sub('', config_json)
     return json.loads(config_json)
+
+def _merge(old, new):
+    result = deepcopy(old)
+    for key, value in new.items():
+        if isinstance(value, dict) and key in result:
+            value = _merge(result[key], value)
+        result[key] = value
+
+    return result
+
+def parse(default_config_filename, override_config_filename = None):
+    config = _parse(default_config_filename)
+    if override_config_filename:
+        try:
+            config = _merge(config, _parse(override_config_filename))
+        except FileNotFoundError:
+            pass
+
+    return config

--- a/dixit/server.py
+++ b/dixit/server.py
@@ -1,6 +1,6 @@
 """Entry point for running the Dixit server.
 
-Usage: python server.py [config.json]
+Usage: python server.py
 
 See https://github.com/arvoelke/dixit or README.md for more information.
 
@@ -394,8 +394,9 @@ settings = {
     'debug' : False,
 }
 
-configFilename = os.path.join(os.path.dirname(__file__), "config.json")
-settings.update(config.parse(configFilename))
+default_config_filename = os.path.join(os.path.dirname(__file__), 'config.json')
+override_config_filename = os.path.join(os.path.dirname(__file__), 'config.local.json')
+settings.update(config.parse(default_config_filename, override_config_filename))
 
 application = Application([
     (r'/', MainHandler),

--- a/dixit/server.py
+++ b/dixit/server.py
@@ -1,6 +1,9 @@
 """Entry point for running the Dixit server.
 
-Usage: python server.py
+Usage: dixit [config.local.json]
+
+where `config.local.json` is optionally a file containing a subset of
+the configuration in `config.json`.
 
 See https://github.com/arvoelke/dixit or README.md for more information.
 
@@ -10,6 +13,7 @@ Refer to LICENSE.txt for terms of modification and redistribution.
 import tornado.ioloop
 import tornado.web
 
+import logging
 import json
 import os
 import sys
@@ -24,6 +28,8 @@ from dixit.utils import INFINITY, hash_obj, get_sorted_positions, url_join, \
     capture_stdout
 import dixit.config as config
 import dixit.display as display
+
+logger = logging.getLogger(__name__)
 
 
 class RequestHandler(tornado.web.RequestHandler):
@@ -395,7 +401,12 @@ settings = {
 }
 
 default_config_filename = os.path.join(os.path.dirname(__file__), 'config.json')
-override_config_filename = os.path.join(os.path.dirname(__file__), 'config.local.json')
+if len(sys.argv) == 2:
+    override_config_filename = sys.argv[1]
+    logger.info("Overriding configuration using the file: %s",
+                override_config_filename)
+else:
+    override_config_filename = None
 settings.update(config.parse(default_config_filename, override_config_filename))
 
 application = Application([


### PR DESCRIPTION
Tested with `dixit/config.local.json` as:
```
{
    // Port for the server to listen on.
    "port" : 8889,

    "limits" : {
        "min_clue_length": 1,
        "min_user_name" : 2
    }
}
```

All three settings were overridden as expected.

The main motivation was exactly these 3: in some languages names can be shorter than 3 char, and clues can be meaningful even with less than 3 chars. And of course it's nice being able to override the port without having a change in the repo.

I've also removed the hint for passing in the config name as an argument as that never really worked.