### PR TITLE
Added option for cards folder

### DIFF
--- a/dixit/config.json
+++ b/dixit/config.json
@@ -2,6 +2,10 @@
     // Port for the server to listen on.
     "port" : 8888,
 
+    // Directory containing available card sets. Path relative to python files directory
+    // If you change this, you have to serve this folder to base_url/static/cards/
+    "card_folder" : "./static/cards/",
+
     // Sets of cards available, used to build a deck for a game.
     "card_sets" : {
         // <name-of-card-set> : [static/cards/<folder>, <is-default-checked>]

--- a/dixit/server.py
+++ b/dixit/server.py
@@ -383,11 +383,14 @@ def has_suffix(name, suffixes):
     return True in (name.endswith(suffix) for suffix in suffixes)
 
 
-def find_cards(folder, suffixes=(".jpg", ".png")):
+def find_cards(folder, deck, suffixes=(".jpg", ".png")):
     """Returns all urls for a given folder, matching the given suffixes."""
-    path = os.path.join(os.path.dirname(__file__), display.WebPaths.CARDS, folder)
+    if folder.startswith('/'):
+        path = os.path.join(folder, deck)
+    else:
+        path = os.path.join(os.path.dirname(__file__), folder, deck)
     return [
-        url_join(display.WebPaths.CARDS, folder, name)
+        url_join(display.WebPaths.CARDS, deck, name)
         for name in os.listdir(path)
         if has_suffix(name, suffixes)
     ]
@@ -406,7 +409,7 @@ class Application(tornado.web.Application):
 
         # Specifies where to find all the card images for each set.
         self.card_sets = [
-            CardSet(name, find_cards(folder), enabled)
+            CardSet(name, find_cards(kwargs["card_folder"],folder), enabled)
             for name, (folder, enabled) in kwargs["card_sets"].items()
         ]
         self.admin_password = kwargs["admin_password"]


### PR DESCRIPTION
I added an option in config.json so one can specify where are the cards stored. It allows to keep the sites-package clean of external modification.

If config.json is something else than ./static/cards, then the user should take care of serving the specified folder to http://host/static/cards/

If you have any question or any modification you think i should do, please tell me !

I am doing a PR because i think this could be of some use to other people who could want to deploy this